### PR TITLE
Border-width, border-color and border-style modules are not working

### DIFF
--- a/tachyons.scss
+++ b/tachyons.scss
@@ -32,11 +32,11 @@
 @import "scss/_aspect-ratios";
 @import "scss/_background-position";
 @import "scss/_background-size";
+@import "scss/_borders";
 @import "scss/_border-colors";
 @import "scss/_border-radius";
 @import "scss/_border-style";
 @import "scss/_border-widths";
-@import "scss/_borders";
 @import "scss/_box-shadow";
 @import "scss/_box-sizing";
 @import "scss/_clears";


### PR DESCRIPTION
Fix: It looks like `@import "scss/_borders";` needs to be called first in `tachyons.scss` before other border modules.