### PR TITLE
update to tachyons 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tachyons-sass",
   "description": "Transpiled Sass partials for Tachyons",
   "author": "John Otander",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "style": "tachyons.scss",
   "scripts": {
     "start": "node build.js",
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "tachyons": "^4.8.1"
+    "tachyons": "^4.9.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/scss/_flexbox.scss
+++ b/scss/_flexbox.scss
@@ -73,6 +73,12 @@
 .order-8 { order: 8; }
 .order-last { order: 99999; }
 
+.flex-grow-0 { flex-grow: 0; }
+.flex-grow-1 { flex-grow: 1; }
+
+.flex-shrink-0 { flex-shrink: 0; }
+.flex-shrink-1 { flex-shrink: 1; }
+
 @media #{$breakpoint-not-small} {
   .flex-ns { display: flex; }
   .inline-flex-ns { display: inline-flex; }
@@ -124,6 +130,12 @@
   .order-7-ns { order: 7; }
   .order-8-ns { order: 8; }
   .order-last-ns { order: 99999; }
+
+  .flex-grow-0-ns { flex-grow: 0; }
+  .flex-grow-1-ns { flex-grow: 1; }
+
+  .flex-shrink-0-ns { flex-shrink: 0; }
+  .flex-shrink-1-ns { flex-shrink: 1; }
 }
 @media #{$breakpoint-medium} {
   .flex-m { display: flex; }
@@ -176,6 +188,12 @@
   .order-7-m { order: 7; }
   .order-8-m { order: 8; }
   .order-last-m { order: 99999; }
+
+  .flex-grow-0-m { flex-grow: 0; }
+  .flex-grow-1-m { flex-grow: 1; }
+
+  .flex-shrink-0-m { flex-shrink: 0; }
+  .flex-shrink-1-m { flex-shrink: 1; }
 }
 
 @media #{$breakpoint-large} {
@@ -230,4 +248,10 @@
   .order-7-l { order: 7; }
   .order-8-l { order: 8; }
   .order-last-l { order: 99999; }
+
+  .flex-grow-0-l { flex-grow: 0; }
+  .flex-grow-1-l { flex-grow: 1; }
+
+  .flex-shrink-0-l { flex-shrink: 0; }
+  .flex-shrink-1-l { flex-shrink: 1; }
 }

--- a/tachyons.scss
+++ b/tachyons.scss
@@ -1,4 +1,4 @@
-// ! TACHYONS v4.8.1 | http://tachyons.io 
+// ! TACHYONS v4.9.0 | http://tachyons.io 
 
 //
 //

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,9 +3424,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-tachyons@^4.8.1:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/tachyons/-/tachyons-4.8.1.tgz#9a3183feecb3240c4dcefee7feecc8259acd7381"
+tachyons@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/tachyons/-/tachyons-4.9.0.tgz#2df058ea6b6eb3d2be12d62a69fecb0f6b1e0534"
 
 tar-pack@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
Update to Tachyons 4.9.0.

I followed what was done in https://github.com/tachyons-css/tachyons-sass/pull/22:

I updated Tachyons to 4.9.0, ran `yarn install`, and `yarn run start`. Am I missing anything?