### PR TITLE
flexbox should be included before display

### DIFF
--- a/tachyons.scss
+++ b/tachyons.scss
@@ -56,8 +56,8 @@
  @import 'scss/code';
  @import 'scss/coordinates';
  @import 'scss/clears';
- @import 'scss/display';
  @import 'scss/flexbox';
+ @import 'scss/display';
  @import 'scss/floats';
  @import 'scss/font-family';
  @import 'scss/font-style';


### PR DESCRIPTION
In order to match the main tachyons.css the flexbox styles should come before the display styles rather than after.  Without this change the following does not render correctly:

```
<div class="flex dn-ns">Should only be visible on small screens</div>
```

However, this div will always be visible.