### PR TITLE
Remove IE7 CSS hack

### DIFF
--- a/scss/_clears.scss
+++ b/scss/_clears.scss
@@ -18,7 +18,6 @@
 .cf:before,
 .cf:after { content: " "; display: table; }
 .cf:after { clear: both; }
-.cf {       *zoom: 1; }
 
 .cl { clear: left; }
 .cr { clear: right; }


### PR DESCRIPTION
Remove this [star property hack](https://stackoverflow.com/a/14927670/808699) that was targeting IE 5.5 to 7.

It causes warnings during ESBuild's CSS minification and IE 7 has a global market share of 0.01% so I think it can be safely dropped.