### PR TITLE
Bump `tachyons-sass` version from 4.9.5 to 4.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tachyons-sass",
-  "version": "4.9.5",
+  "version": "4.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tachyons-sass",
   "description": "Transpiled Sass partials for Tachyons",
   "author": "John Otander",
-  "version": "4.9.5",
+  "version": "4.9.6",
   "style": "tachyons.scss",
   "scripts": {
     "start": "node build.js",


### PR DESCRIPTION
Bumping package version from `4.9.5` to `4.9.6` and publishing to npm is required so https://github.com/tachyons-css/tachyons-sass/pull/56 can take effect on projects.